### PR TITLE
support for bulk downloaded files

### DIFF
--- a/laff/bulklc.py
+++ b/laff/bulklc.py
@@ -1,0 +1,101 @@
+"""!!!Not really usable yet, more for personal use.!!!"""
+
+
+import swifttools.ukssdc.data.GRB as udg
+import swifttools.ukssdc.query as uq
+import pandas as pd
+import argparse
+from astropy.table import Table
+
+"""Wrapper around swifttools module to bulk download GRB light curves in a LAFF suitable format."""
+
+
+parser = argparse.ArgumentParser(description='Bulk download Swift XRT GRB light curves.', prog='laff-bulk')
+
+parser.add_argument('output', nargs=1, metavar='output_directory', type=str, help='Output directory path for downloaded files.')
+
+args = parser.parse_args()
+
+output_path = args.output[0]
+
+# Setup query object.
+q = uq.GRBQuery(cat='SDC_GRB')
+q.addCol('Name')
+q.addCol('TriggerNumber')
+
+# Add filters.
+filter1 = ('Name', '>', 'GRB 190912A')
+filter2 = ('BAT_T90', '>', '2')
+q.addFilter(filter1)
+q.addFilter(filter2)
+
+# Search.
+q.submit()
+grb_names, grb_triggers = list(q.results['Name']), list(q.results['TriggerNumber'])
+
+# Store lightcurves.
+lightcurves = udg.getLightCurves(targetID=grb_triggers[0:5],
+                    incbad='yes',
+                    saveData=False,
+                    returnData = True,
+                    silent=False)
+
+# Organise observation modes and save to file.
+for name, trigID in zip(grb_names, lightcurves):
+
+    try:    # Look for slew mode data.
+        lightcurves[trigID]['WTSLEW_incbad']
+        sl = True
+    except:
+        sl = False
+
+    try:    # Look for WT mode data.
+        lightcurves[trigID]['WT_incbad']
+        wt = True
+    except:
+        wt = False
+
+    try:    # Look for PC mode data.
+        lightcurves[trigID]['PC_incbad']
+        pc = True
+    except:
+        pc = False
+
+    columns = ['Time','TimePos','TimeNeg','Rate','RatePos','RateNeg']
+    table = []
+    if sl:
+        table.append(lightcurves[trigID]['WTSLEW_incbad'][columns])
+    if wt:
+        table.append(lightcurves[trigID]['WT_incbad'][columns])
+    if pc:
+        table.append(lightcurves[trigID]['PC_incbad'][columns])
+
+    if sl or wt or pc:
+        fulltable = pd.concat([mode for mode in table])
+        fulltable = fulltable.sort_values(by=['Time'])
+        fulltable = fulltable.reset_index(drop=True)
+
+        grb_lc = Table.from_pandas(fulltable)
+        filepath = output_path+'/'+name.replace(' ','')+'.qdp'
+        print(filepath)
+        grb_lc.write(filepath, err_specs={'terr': [1, 2]})
+
+def getSwiftLC():
+
+    """
+
+    This function takes the standard .qdp lightcurve data available on the 
+    Swift online archive, and outputs the formatted table ready for LAFF.
+    XRT Lightcurves can sometimes contain upper limits, this function also
+    excludes importing this data.
+
+    [Parameters]
+        filepath (str):
+            Filepath to lightcurve data.
+
+    [Returns]
+        data (pandas table): 
+            Formatting data table object ready for LAFF.
+    """
+
+    return

--- a/laff/lcimport.py
+++ b/laff/lcimport.py
@@ -2,7 +2,7 @@ from astropy.table import Table, vstack
 import pandas as pd
 
 
-"""laff.models: models module within the laff package."""
+"""laff.lcimport: lightcurve importing module within the laff package."""
 
 class Imports(object):
 
@@ -24,7 +24,6 @@ class Imports(object):
             data (pandas table): 
                 Formatting data table object ready for LAFF.
         """
-
         acceptable_modes = (['WTSLEW'], ['WT'], ['PC_incbad'])
 
         qdptable = []
@@ -36,15 +35,47 @@ class Imports(object):
             except:
                 continue
 
-            # Exclude data tables that aren't in the corect observing mode.
+            # Exclude data tables that aren't in the correct observing mode.
+            # Check first for _incbad mode (usually default).
             if import_table.meta['comments'] in acceptable_modes:
                 qdptable.append(import_table)
-            else:
-                pass
             i += 1
 
         # Combine data into one table, format
         data = vstack(qdptable).to_pandas()
+        data = data.sort_values(by=['col1'])
+        data = data.reset_index(drop=True)
+        data = data.rename(columns={
+            'col1': 'time', 'col1_perr': 'time_perr', 'col1_nerr': 'time_nerr',
+            'col2': 'flux', 'col2_perr': 'flux_perr', 'col2_nerr': 'flux_nerr'})
+        data['flare'] = False
+
+        return data
+
+    def swift_bulk(filepath):
+
+        """
+        Import a lightcurve from Swift-XRT downloaded through laff.bulklc.
+
+        This function imports standard .qdp lightcurve data from the Swift XRT
+        telescope. This function is likely temporary and for personal use and
+        the main function will fully support various formats of LC. The bulklc
+        module imports data into one large table removing the various
+        observation modes, hence the need for a slightly different import
+        method.
+
+        [Parameters]
+            filepath (str):
+                Filepath to lightcurve data.
+
+        [Returns]
+            data (pandas table): 
+                Formatting data table object ready for LAFF.
+        """
+
+        import_table = Table.read(filepath, format='ascii.qdp', table_id=i)
+
+        data = vstack(import_table).to_pandas()
         data = data.sort_values(by=['col1'])
         data = data.reset_index(drop=True)
         data = data.rename(columns={


### PR DESCRIPTION
+ Add support for bulk downloaded swift files
	In this case the qdp tables will not be segmented into obs type -t his is already done
+ force fit_flare to return abs(params)

(bulklc.py)
+ A wrapper script around swifttools module. Imports GRB light curves based on filters and saves the table in a nice format for LAFF.
	Really only temporary and for personal use.
	
(lcimport.py)
+ Support for Swift XRT bulk files. Mainly only for personal use.
	At some point I will wrap all the support into the main mission function.

/ modify some parser argument names
/ change the force argument - just forces number of breaks now. Simplified
/ require astropy>=5.1
Seemed to be some error between astropy and numpy at earlier versions