### PR TITLE
update version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "laff"
-version = "0.11.2"
+version = "0.12.0"
 description = "GRB lightcurve flare and continuum fitter."
 authors = ["Adam Hennessy <ah724@leicester.ac.uk>"]
 readme = "README.md"


### PR DESCRIPTION
finalise converting the fitting function for afterglow

- flare data is taken as upper limits
- now using fmin_slsqp module to fit instead of ODR (parameter bounds, quicker/more reliable, constraints)
- manual calculation of best fit errors